### PR TITLE
Add vast.ai deployment with persistent COCO storage

### DIFF
--- a/setup_vastai.sh
+++ b/setup_vastai.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Vast.ai setup script for SSDLite MobileNetV2 training
+#
+# Usage:
+#   1. Rent a GPU instance on vast.ai with:
+#      - Docker image: pytorch/pytorch:2.6.0-cuda12.8-cudnn9-runtime
+#      - Disk space: 50GB+ (or use persistent /workspace storage)
+#   2. SSH into the instance
+#   3. Run: bash setup_vastai.sh
+#
+# COCO dataset is stored in /workspace/coco so it persists across instances.
+# If /workspace is not available (no persistent storage), falls back to local data/COCO.
+
+set -e
+
+echo "=== SSDLite Training Setup for vast.ai ==="
+
+# ---- 1. Clone repo ----
+echo "[1/5] Cloning repository..."
+REPO_DIR="MIRPR-pedestrian-and-vehicle-detection-SSDLite"
+if [ ! -d "$REPO_DIR" ]; then
+    git clone https://github.com/pasandrei/MIRPR-pedestrian-and-vehicle-detection-SSDLite.git
+fi
+cd "$REPO_DIR"
+
+# ---- 2. Install dependencies ----
+echo "[2/5] Installing Python dependencies..."
+pip install --quiet \
+    albumentations \
+    pycocotools \
+    tensorboard \
+    opencv-python-headless
+
+# ---- 3. Download COCO dataset ----
+# Use /workspace for persistent storage across vast.ai instances
+if [ -d "/workspace" ]; then
+    COCO_DIR="/workspace/coco"
+    echo "[3/5] Using persistent storage at $COCO_DIR"
+else
+    COCO_DIR="$(pwd)/data/COCO"
+    echo "[3/5] No persistent storage found, using local $COCO_DIR"
+fi
+
+mkdir -p "$COCO_DIR"
+
+REPO_ROOT="$(pwd)"
+
+download_coco() {
+    local dir="$1"
+    cd "$dir"
+
+    if [ ! -d "train2017" ]; then
+        echo "  Downloading train2017 (~18GB)..."
+        wget -q --show-progress http://images.cocodataset.org/zips/train2017.zip
+        unzip -q train2017.zip
+        rm train2017.zip
+    else
+        echo "  train2017 already exists, skipping"
+    fi
+
+    if [ ! -d "val2017" ]; then
+        echo "  Downloading val2017 (~1GB)..."
+        wget -q --show-progress http://images.cocodataset.org/zips/val2017.zip
+        unzip -q val2017.zip
+        rm val2017.zip
+    else
+        echo "  val2017 already exists, skipping"
+    fi
+
+    if [ ! -d "annotations" ]; then
+        echo "  Downloading annotations (~250MB)..."
+        wget -q --show-progress http://images.cocodataset.org/annotations/annotations_trainval2017.zip
+        unzip -q annotations_trainval2017.zip
+        rm annotations_trainval2017.zip
+    else
+        echo "  annotations already exists, skipping"
+    fi
+}
+
+download_coco "$COCO_DIR"
+cd "$REPO_ROOT"
+
+# Symlink persistent COCO into repo if using /workspace
+if [ -d "/workspace" ]; then
+    mkdir -p data
+    if [ -L "data/COCO" ]; then
+        rm data/COCO
+    fi
+    ln -sf "$COCO_DIR" data/COCO
+    echo "  Symlinked data/COCO -> $COCO_DIR"
+fi
+
+# ---- 4. Verify setup ----
+echo "[4/5] Verifying setup..."
+python -c "
+import torch
+print(f'PyTorch: {torch.__version__}')
+print(f'CUDA available: {torch.cuda.is_available()}')
+if torch.cuda.is_available():
+    print(f'GPU: {torch.cuda.get_device_name(0)}')
+    print(f'GPU Memory: {torch.cuda.get_device_properties(0).total_mem / 1e9:.1f} GB')
+
+from pathlib import Path
+coco = Path('data/COCO')
+assert (coco / 'train2017').exists(), 'train2017 not found'
+assert (coco / 'val2017').exists(), 'val2017 not found'
+assert (coco / 'annotations/instances_train2017.json').exists(), 'train annotations not found'
+assert (coco / 'annotations/instances_val2017.json').exists(), 'val annotations not found'
+print('COCO dataset: OK')
+
+import albumentations, pycocotools
+print('Dependencies: OK')
+"
+
+# ---- 5. Print run instructions ----
+echo ""
+echo "=== Setup complete ==="
+echo ""
+echo "To start training (use screen to survive SSH disconnect):"
+echo "  screen -S train"
+echo "  PYTHONUNBUFFERED=1 python main.py > training.log 2>&1 &"
+echo "  tail -f training.log"
+echo "  # Ctrl+A, D to detach; screen -r train to reattach"
+echo ""
+echo "To monitor progress:"
+echo "  grep -E 'Epoch:|Average Precision.*all.*100|Model saved' training.log | tail -20"

--- a/setup_vastai.sh
+++ b/setup_vastai.sh
@@ -30,10 +30,12 @@ fi
 # ---- 2. Install dependencies ----
 echo "[2/5] Installing Python dependencies..."
 pip install --quiet \
-    albumentations \
+    'albumentations<2' \
     pycocotools \
     tensorboard \
-    opencv-python-headless
+    opencv-python-headless \
+    aria2p
+apt-get update -qq && apt-get install -y -qq aria2 unzip >/dev/null 2>&1 || true
 
 # ---- 3. Download COCO dataset ----
 # Use /workspace for persistent storage across vast.ai instances
@@ -57,7 +59,7 @@ download_coco() {
 
     if [ ! -d "train2017" ]; then
         echo "  Downloading train2017 (~19GB)..."
-        wget -q --show-progress "$HF_BASE/train2017.zip"
+        aria2c -x 16 -s 16 -q --auto-file-renaming=false -o train2017.zip "$HF_BASE/train2017.zip"
         unzip -q train2017.zip
         rm train2017.zip
     else
@@ -66,7 +68,7 @@ download_coco() {
 
     if [ ! -d "val2017" ]; then
         echo "  Downloading val2017 (~800MB)..."
-        wget -q --show-progress "$HF_BASE/val2017.zip"
+        aria2c -x 16 -s 16 -q --auto-file-renaming=false -o val2017.zip "$HF_BASE/val2017.zip"
         unzip -q val2017.zip
         rm val2017.zip
     else
@@ -75,7 +77,7 @@ download_coco() {
 
     if [ ! -d "annotations" ]; then
         echo "  Downloading annotations (~250MB)..."
-        wget -q --show-progress "$HF_BASE/annotations_trainval2017.zip"
+        aria2c -x 16 -s 16 -q --auto-file-renaming=false -o annotations_trainval2017.zip "$HF_BASE/annotations_trainval2017.zip"
         unzip -q annotations_trainval2017.zip
         rm annotations_trainval2017.zip
     else
@@ -94,6 +96,13 @@ if [ -d "/workspace" ]; then
     fi
     ln -sf "$COCO_DIR" data/COCO
     echo "  Symlinked data/COCO -> $COCO_DIR"
+fi
+
+# Create stats.json if missing (removed from git tracking)
+STATS_FILE="misc/experiments/ssdlite/stats.json"
+if [ ! -f "$STATS_FILE" ]; then
+    echo '{"loss": 9999, "mAP": 0}' > "$STATS_FILE"
+    echo "  Created $STATS_FILE"
 fi
 
 # ---- 4. Verify setup ----

--- a/setup_vastai.sh
+++ b/setup_vastai.sh
@@ -16,12 +16,16 @@ set -e
 echo "=== SSDLite Training Setup for vast.ai ==="
 
 # ---- 1. Clone repo ----
-echo "[1/5] Cloning repository..."
-REPO_DIR="MIRPR-pedestrian-and-vehicle-detection-SSDLite"
-if [ ! -d "$REPO_DIR" ]; then
-    git clone https://github.com/pasandrei/MIRPR-pedestrian-and-vehicle-detection-SSDLite.git
+echo "[1/5] Setting up repository..."
+if [ -f "setup_vastai.sh" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "  Already inside repo, skipping clone"
+else
+    REPO_DIR="MIRPR-pedestrian-and-vehicle-detection-SSDLite"
+    if [ ! -d "$REPO_DIR" ]; then
+        git clone https://github.com/pasandrei/MIRPR-pedestrian-and-vehicle-detection-SSDLite.git
+    fi
+    cd "$REPO_DIR"
 fi
-cd "$REPO_DIR"
 
 # ---- 2. Install dependencies ----
 echo "[2/5] Installing Python dependencies..."

--- a/setup_vastai.sh
+++ b/setup_vastai.sh
@@ -53,9 +53,11 @@ download_coco() {
     local dir="$1"
     cd "$dir"
 
+    HF_BASE="https://huggingface.co/datasets/pcuenq/coco-2017-mirror/resolve/main"
+
     if [ ! -d "train2017" ]; then
-        echo "  Downloading train2017 (~18GB)..."
-        wget -q --show-progress http://images.cocodataset.org/zips/train2017.zip
+        echo "  Downloading train2017 (~19GB)..."
+        wget -q --show-progress "$HF_BASE/train2017.zip"
         unzip -q train2017.zip
         rm train2017.zip
     else
@@ -63,8 +65,8 @@ download_coco() {
     fi
 
     if [ ! -d "val2017" ]; then
-        echo "  Downloading val2017 (~1GB)..."
-        wget -q --show-progress http://images.cocodataset.org/zips/val2017.zip
+        echo "  Downloading val2017 (~800MB)..."
+        wget -q --show-progress "$HF_BASE/val2017.zip"
         unzip -q val2017.zip
         rm val2017.zip
     else
@@ -73,7 +75,7 @@ download_coco() {
 
     if [ ! -d "annotations" ]; then
         echo "  Downloading annotations (~250MB)..."
-        wget -q --show-progress http://images.cocodataset.org/annotations/annotations_trainval2017.zip
+        wget -q --show-progress "$HF_BASE/annotations_trainval2017.zip"
         unzip -q annotations_trainval2017.zip
         rm annotations_trainval2017.zip
     else

--- a/setup_vastai.sh
+++ b/setup_vastai.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   1. Rent a GPU instance on vast.ai with:
-#      - Docker image: pytorch/pytorch:2.6.0-cuda12.8-cudnn9-runtime
+#      - Docker image: pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime
 #      - Disk space: 50GB+ (or use persistent /workspace storage)
 #   2. SSH into the instance
 #   3. Run: bash setup_vastai.sh

--- a/setup_vastai.sh
+++ b/setup_vastai.sh
@@ -35,7 +35,11 @@ pip install --quiet \
     tensorboard \
     opencv-python-headless \
     aria2p
-apt-get update -qq && apt-get install -y -qq aria2 unzip >/dev/null 2>&1 || true
+apt-get update -qq && apt-get install -y -qq aria2 unzip gcc >/dev/null 2>&1 || true
+# torch.compile needs libcuda.so symlink (runtime images only have libcuda.so.1)
+if [ ! -f /usr/lib/x86_64-linux-gnu/libcuda.so ] && [ -f /usr/lib/x86_64-linux-gnu/libcuda.so.1 ]; then
+    ln -s /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so
+fi
 
 # ---- 3. Download COCO dataset ----
 # Use /workspace for persistent storage across vast.ai instances

--- a/setup_vastai.sh
+++ b/setup_vastai.sh
@@ -98,13 +98,6 @@ if [ -d "/workspace" ]; then
     echo "  Symlinked data/COCO -> $COCO_DIR"
 fi
 
-# Create stats.json if missing (removed from git tracking)
-STATS_FILE="misc/experiments/ssdlite/stats.json"
-if [ ! -f "$STATS_FILE" ]; then
-    echo '{"loss": 9999, "mAP": 0}' > "$STATS_FILE"
-    echo "  Created $STATS_FILE"
-fi
-
 # ---- 4. Verify setup ----
 echo "[4/5] Verifying setup..."
 python -c "


### PR DESCRIPTION
## Summary
- Add `setup_vastai.sh` for one-command setup on vast.ai GPU instances
- Store COCO dataset in `/workspace/coco` (vast.ai persistent volume) so it survives across instances (~20GB download saved on each new instance)
- Symlinks persistent COCO into `data/COCO` so the code works unchanged
- Falls back to local `data/COCO` if no persistent storage is available
- Skips downloads if data already exists

## Test plan
- [ ] Verify script runs on a vast.ai instance with `/workspace` persistent storage
- [ ] Verify COCO data persists after stopping and starting a new instance
- [ ] Verify training starts successfully after setup